### PR TITLE
Add files to gitignore and improve building on linux platforms.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
 doxygen_documentation
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake
+source/CMakeFiles
+source/Makefile
+source/cath_tools_git_version/
+source/cmake_install.cmake
+source/libct_biocore.a
+source/libct_cath_score_align.a
+source/libct_chopping.a
+source/libct_common.a
+source/libct_display_colour.a
+source/libct_options.a
+source/libct_uni.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,11 @@ MESSAGE( STATUS "Running under CMake v" ${CMAKE_VERSION} )
 # If on Linux, get the release codename
 IF( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" )
 	find_program   ( LSB_RELEASE lsb_release )
-	execute_process( COMMAND ${LSB_RELEASE} -cs OUTPUT_VARIABLE LSB_RELEASE_CODE OUTPUT_STRIP_TRAILING_WHITESPACE)
+	IF( NOT LSB_RELEASE )
+		SET( LSB_RELEASE_CODE "Unspecified" )
+	ELSE()
+		execute_process( COMMAND ${LSB_RELEASE} -cs OUTPUT_VARIABLE LSB_RELEASE_CODE OUTPUT_STRIP_TRAILING_WHITESPACE)
+	ENDIF()
 ELSE()
 	# Else set LSB_RELEASE_CODE to something else so the upcoming STREQUAL makes sense
 	SET( LSB_RELEASE_CODE ${CMAKE_SYSTEM_NAME} )


### PR DESCRIPTION
Catching a few quick things.  First, usually you want to ignore all your intermediate build files and resulting binaries.  Second, this should catch my case on Arch Linux where any notion of LSB is just not a thing.  It should also prove more stable for building in future releases of Ubuntu as well.

Granted, pulling in static libraries like you are is probably not the best thing to do.  You should consider switching to shared libraries or a build time switch.  