### PR TITLE
update dependencies for perl tests

### DIFF
--- a/perl/Makefile.PL
+++ b/perl/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use inc::Module::Install;
-use Module::Install::External;
+#use Module::Install::External;
 use 5.008;
 
 name 'cath-tools';
@@ -10,7 +10,14 @@ perl_version '5.008';
 license 'perl';
 version '0.0.1';
 
+test_requires 'File::Slurp';
+test_requires 'File::Temp';
+test_requires 'IPC::Cmd';
+test_requires 'Path::Class';
+test_requires 'Readonly';
 test_requires 'Test::Class';
+test_requires 'Test::Files';
+test_requires 'Try::Tiny';
 
 tests_recursive();
 


### PR DESCRIPTION
I think these were really intended for internal use (as part of the internal build/release).

However, doesn't hurt to keep them up to date.

Note: my basic system perl didn't provide `inc::Module::Install::External`and it didn't look like it was actually being used so I just commented it out for now.

The others are just based on the modules observed in the other tests.

